### PR TITLE
Validate terraform files from terraform path, not repo path

### DIFF
--- a/bin/tf_validate.sh
+++ b/bin/tf_validate.sh
@@ -12,5 +12,5 @@ done
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   pushd "$path_uniq" > /dev/null
   terraform validate
-  popd
+  popd > /dev/null
 done

--- a/bin/tf_validate.sh
+++ b/bin/tf_validate.sh
@@ -10,5 +10,7 @@ for file_with_path in "$@"; do
 done
 
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-  terraform validate "$path_uniq"
+  pushd $path_uniq
+  terraform validate
+  popd
 done

--- a/bin/tf_validate.sh
+++ b/bin/tf_validate.sh
@@ -10,7 +10,7 @@ for file_with_path in "$@"; do
 done
 
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-  pushd $path_uniq
+  pushd "$path_uniq"
   terraform validate
   popd
 done

--- a/bin/tf_validate.sh
+++ b/bin/tf_validate.sh
@@ -10,7 +10,7 @@ for file_with_path in "$@"; do
 done
 
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
-  pushd "$path_uniq"
+  pushd "$path_uniq" > /dev/null
   terraform validate
   popd
 done


### PR DESCRIPTION
`terraform validate <path>` returns some false-positive errors in our usage whereas `terraform validate` from the correct path does not. This PR updates the script to use the latter when calling `terraform validate`.

Testing:
(valid) terraform change on this branch:
```
Check for merge conflicts................................................Passed
Flake8...............................................(no files to check)Skipped
Trim Trailing Whitespace.............................(no files to check)Skipped
jshint...............................................(no files to check)Skipped
eslint...............................................(no files to check)Skipped
terraform_fmt............................................................Passed
terraform_validate.......................................................Passed
[gs-sls-envs 6f0b993f6] temp change
 1 file changed, 1 insertion(+), 1 deletion(-)
```

(valid) terraform change on master:

```
Gabes-MacBook-Pro-2:EZapp-public gabesmed$ git commit -m 'temp change'
Check for merge conflicts................................................Passed
Flake8...............................................(no files to check)Skipped
Trim Trailing Whitespace.............................(no files to check)Skipped
jshint...............................................(no files to check)Skipped
eslint...............................................(no files to check)Skipped
terraform_fmt............................................................Passed
terraform_validate.......................................................Failed
hookid: terraform_validate

Failed to load root config module: Error loading modules: module network: not found, may need to be downloaded using 'terraform get'
```