### PR TITLE
Use `-check-variables=false` flag in terraform validate

### DIFF
--- a/bin/tf_validate.sh
+++ b/bin/tf_validate.sh
@@ -11,6 +11,6 @@ done
 
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   pushd "$path_uniq" > /dev/null
-  terraform validate --check-variables=false
+  terraform validate -check-variables=false
   popd > /dev/null
 done

--- a/bin/tf_validate.sh
+++ b/bin/tf_validate.sh
@@ -11,6 +11,6 @@ done
 
 for path_uniq in $(echo "${paths[*]}" | tr ' ' '\n' | sort -u); do
   pushd "$path_uniq" > /dev/null
-  terraform validate
+  terraform validate --check-variables=false
   popd > /dev/null
 done


### PR DESCRIPTION
Terraform 0.10.0 now checks that all variables are specified by default (see https://github.com/hashicorp/terraform/pull/13872) . It now provides a `-check-variables` flag to the validate command to have it use the old behavior.

The pre-commit hook should *not* check variables because if it does so, generic modules meant to be imported by other terraform environments will fail the validate hook if they have any required inputs.