### PR TITLE
Use file type instead extension

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,8 @@
   description: Formats terraform scripts into the correct checkstyle
   entry: bin/tf_fmt.sh
   language: script
-  files: \.tf$
+  types:
+    - terraform
   exclude: \.terraform\/.*$
 
 - id: terraform_validate
@@ -11,7 +12,8 @@
   description: Validates terraform scripts syntax
   entry: bin/tf_validate.sh
   language: script
-  files: \.tf$
+  types:
+    - terraform
   exclude: \.terraform\/.*$
 
 - id: prometheus_check_rules


### PR DESCRIPTION
Using types are better option than using file extension. 

For instance, the hooks are neither `fmt`-ing nor validatees `.tfvars` files currently. However, if types are used, detected by https://github.com/pre-commit/identify and `pre-commit` runs accordinly. Which means [these two file extensions](https://github.com/pre-commit/identify/blob/master/identify/extensions.py#L179-L180) will be `fmt`-ed and verified.  👍 